### PR TITLE
Fix small bug in logging that was causing a crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,9 +81,7 @@ WMSSource.prototype.getTile = function(z, x, y, callback) {
     retry_options,
     function(error, response, body) {
       debug(
-        `Received response for url ${response.request.href} status:${
-          response.statusCode
-        }`
+        response
       );
       if (error) {
         return callback(error);


### PR DESCRIPTION
There was a bug printing a debug statement that was causing this to crash. A property was trying to be accessed from an `undefined` object. I'm going to merge this without review. 