### PR TITLE
Specify BBOX CRS when sending getMap request to WMS server

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ WMSSource.prototype.getTile = function(z, x, y, callback) {
     service: "WMS",
     request: "GetMap",
     version: "1.1.1",
+    bboxSR:'900913',
     layers: "",
     styles: "",
     transparent: false,


### PR DESCRIPTION
Going to merge this without review. Tested on several map sources. 